### PR TITLE
Re-initialize the RAWG API when saving settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Obsidian Game Search Plugin
 
-- [How to install](#how-to-install)
+- [How to Install](#how-to-install)
 - [Basic Usage](#basic-usage)
 - [Steam Sync](#steam-sync)
 - [Templating](#templating)
   - [Example Template](#example-template)
-  - [Template variables definitions](#template-variables-definitions)
-  - [Regenerating files from new template](#regenerating-file-metadata)
+  - [Template Variable Definitions](#template-variables-definitions)
+  - [Regenerating File Metadata](#regenerating-file-metadata)
 
-## forked from
+## Forked From
 
 https://github.com/anpigon/obsidian-book-search-plugin/
 
@@ -16,14 +16,7 @@ https://github.com/anpigon/obsidian-book-search-plugin/
 
 Use to query game using a game title (uses RAWG Game API to get the game information.)
 
-**PLEASE NOTE THAT CREATING AN API KEY ON RAWG SEEMS TO TAKE SOME TIME TO ACTIVATE**
-**TRYING TO USE A KEY IMMEDIATELY AFTER CREATING IT SEEMS TO OFTEN RESULT IN 401 ERRORS**.
-
-### BEFORE OPENING AN ISSUE REGARDING RAWG KEYS AND 401 ERRORS PLEASE ENSURE YOU HAVE WAITED SOME AND TRIED AGAIN
-
-**(see initial issue [here](https://github.com/CMorooney/obsidian-game-search-plugin/issues/11))**
-
-## How to install
+## How to Install
 
 Click the link to install the Game Search plugin: [Install Link](https://github.com/CMorooney/obsidian-game-search-plugin)
 Or, search 'Game Search' in the Obsidian Community plugin directory and install it from there.
@@ -31,34 +24,38 @@ Or, search 'Game Search' in the Obsidian Community plugin directory and install 
 ## Basic Usage
 
 1. Acquire an API key from [RAWG](https://rawg.io/apidocs)
-2. Enter your RAWG API key into the Game Search Plugin Settings
-3. Use command `Create New Game Note` to search for a game
-4. After searching, you will be presented with results -- select one!
-5. Your not has been created :]
+2. Enter your RAWG API key into the Game Search plugin settings
+3. Select a location for your game notes to be created
+4. Enter a file name format
+5. Select a file to use as a note template
+6. Use the command `Create New Game Note` to search for a game
+7. Select a game from the search results
+8. Your note has been created :]
 
 ## Steam Sync
 
 Optionally, you can auto-sync your Steam Library and Wishlist.
 
 1. Acquire an API key from [Steam](https://steamcommunity.com/dev)
-2. Make note of your user SteamId (navigate to your profile on the web and check the url)
-3. Enter your Steam API key and Id into Game Search Plugin Settings
-4. Ensure your Steam Privacy Settings have your wishlist set to `Public` if you wish to sync wishlist
+2. Make note of your user SteamId (navigate to your profile on the web and check the URL)
+3. Enter your Steam API key and Id into the Game Search plugin settings
+4. Ensure your Steam Privacy Settings have your wishlist set to `Public` if you wish to sync wishlist items
 5. (Optional) provide metadata to be injected into wishlisted and/or owned games
-   a. for example, I add `status: backlog` to wishlist games and `owned_platform: steam` to owned games
+   - For example, I add `status: backlog` to wishlist games and `owned_platform: steam` to owned games
 6. Use command `Sync Steam` to begin a sync.
-   a. this is not speedy, especially with larger libraries. There is a progress bar to provide some feedback but just...heads up
-7. **NOTE:** synced Steam games will automatically have a `steamId` metadata property added. don't remove this.
+   - This is not speedy, especially with larger libraries. There is a progress bar to provide some feedback but just...heads up
+7. **NOTE**: Synced Steam games will automatically have a `steamId` metadata property added. Don't remove this.
 
 ## Templating
 
 It is recommended to pair this plugin with [Templater](https://github.com/SilentVoid13/Templater)
 so that you can auto-generate content for your game notes.
 
-### Example template
+### Example Template
 
-Please also find a definition of the variables used in this template below (see: [Template variables definitions](#template-variables-definitions)).
-note: array properties will currently output as a comma separated string
+The following is an example template. A complete list of template variables provided by the plugin
+ can be found under [Template Variable Definitions](#template-variables-definitions). 
+ **Note**: Array properties will output as a comma separated string.
 
 ```
 ---
@@ -83,23 +80,23 @@ Acknowledging that you may adjust your template after adding many many games,
 the plugin provides a button **within the settings panel** to regenerate all of
 your game note metadata.
 
-**In previous versions** of this plugin this button would _completely_ regenerate
-the files and you would lose any non-templated content in them.
+**Previous versions** of this plugin this button would _completely_ regenerate
+the files, and you would lose any non-templated content in them.
 
 **As of v0.2.0** this feature only replaces the metadata of your game files with
-regenerated metadata from the templates. The motiviation behind this is that it
-is likely that the body of a game note is used for keepsake/TODO lists/personal notes
+regenerated metadata from the template. The motivation behind this is that it
+is likely that the body of a game note is used for keepsake/TODO lists/personal notes,
 while the main portion of the templating will happen in the metadata. I'm open to
 revisiting this if it proves to be a bad idea.
 
-**note:** `steamId` and any user-provided metadata to be injected into
-steam games (added via settings) will be preserved
+**Note**: `steamId` and any user-provided metadata to be injected into
+Steam games (added via settings) will be preserved.
 
 ## Other Settings
 
 ### New file location
 
-Set the folder location where the new file is created. Otherwise, a new file is created in the Obsidian Root folder.
+Set the folder location where the new file is created. Otherwise, a new file is created in the Obsidian root folder.
 
 ### New file name
 
@@ -108,38 +105,40 @@ You can use `{{DATE}}` or `{{DATE:YYYYMMDD}}` to set a unique file name.
 
 ### Template variables definitions
 
-Please find here a definition of the possible variables to be used in your template. Simply write `{{name}}` in your template, and replace name by the desired game data, including:
+The following table lists and describes each variable that can be used in your template. To use a 
+variable in your template, simply write the variable name surrounded by curly braces (e.g., 
+`{{name}}`).
 
-| name                 | description                                                   |
+| Name                 | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| id                   | (number) RAWG database Id                                     |
+| id                   | (number) RAWG database ID                                     |
 | slug                 | (string) RAWG game slug                                       |
 | name                 | (string) Name of the game                                     |
 | name_original        | (string) Original name of the game                            |
-| description          | (string) Description of the game, html format                 |
-| description_raw      | (string) Description of the game, raw text                    |
+| description          | (string) Description of the game (HTML)                       |
+| description_raw      | (string) Description of the game (Text)                       |
 | released             | (string) Release date of the game                             |
-| tba                  | (boolean) unknown release date flag                           |
-| background_image     | (string) background image url                                 |
+| tba                  | (boolean) Unknown release date flag                           |
+| background_image     | (string) Background image URL                                 |
 | rating               | ([Rating](#rating_object))                                    |
-| rating_top           | (number), highest rating                                      |
+| rating_top           | (number) Highest rating                                       |
 | ratings              | (array) of [Ratings](#rating_object)                          |
-| ratings_count        | (number) of ratings                                           |
-| reviews_text_count   | (string) number of text reviews                               |
-| metacritic           | (number) metacritic score                                     |
+| ratings_count        | (number) Number of ratings                                    |
+| reviews_text_count   | (string) Number of text reviews                               |
+| metacritic           | (number) Metacritic score                                     |
 | metacritic_platforms | (array) of [MetacriticPlatform](#metacritic_platform_object)) |
-| playtime             | (number) estimated playtime in hours                          |
-| updated              | (string) last updated date in RAWG database                   |
+| playtime             | (number) Estimated playtime in hours                          |
+| updated              | (string) Last updated date in RAWG database                   |
 | esrb_rating          | ([ESRB](#esrb_object)) ESRB rating                            |
 | platforms            | (array) of [Platforms](#platform_object)                      |
 | stores               | (array) of [Stores](#store_object)                            |
 | score                | (number)                                                      |
 | tags                 | (array) of [Tags](#tag_object)                                |
-| saturated_color      | (string) hex color (without `#`)                              |
-| dominant_color       | (string) hex color (without `#`)                              |
+| saturated_color      | (string) Color in hexadecimal format (without `#`)            |
+| dominant_color       | (string) Color in hexadecimal format (without `#`)            |
 | genres               | (array) of [Genres](#genre-object)                            |
 | short_screenshots    | (array) of [ScreenShots](#screenshot-object)                  |
-| website              | (string) url of game website if one exists                    |
+| website              | (string) URL of game website, if one exists                   |
 | publihers            | (array) of [Publishers](#publisher-object)                    |
 | developers           | (array) of [Developers](#developer-object)                    |
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -349,5 +349,8 @@ export default class GameSearchPlugin extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings);
+    
+    // Re-initialize the API, in case the API key was changed
+    this.rawgApi = new RAWGAPI(this.settings.rawgApiKey);
   }
 }


### PR DESCRIPTION
**Problem**: The `rawgAPI` was only set when the plugin initially loaded. A user could enter their API key on the settings page, but the plugin wouldn't start using the API key until the plugin was reloaded (e.g., when the user closed and re-opened Obsidian). I believe this to be the most likely cause of the 401 errors that would seemingly resolve in time.

**Solution**: Added a line to the `saveSettings()` function that re-initializes the API, thus immediately picking up on changes to the API key.

**Testing**:
- Original
    1. Successfully searched for a game with a working API key (to ensure everything was working to begin with)
    2. Changed the API key to something obviously invalid (e.g., `5555555`)
    3. Searched for a different game
        - The search still worked because the API wasn't re-initialized and was still using the valid key
- Modified Version
    1. Successfully searched for a game with a working API key (to ensure everything was working to begin with)
    2. Changed the API key to something obviously invalid (e.g., `5555555`)
    3. Searched for a different game
        - The search failed with a `401` error because the API key was invalid
    4. Refreshed my RAWR API key
    5. Configured Game Search to use the new API key
    6. Searched for a game
        - The search completed successfully (less than a minute after refreshing the key)

