### PR TITLE
Correctly fix colon when regenerating files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.4
+
+Fixes bug where regenerating metadata for game files would incorrectly format a string
+that included a colon.
+
 ## 0.2.3
 
 Fixes bug where re-generating metadata for game files would

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "game-search",
   "name": "Game Search",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "minAppVersion": "0.15.0",
   "description": "Helps you find games and create notes. Optional Steam Library Sync",
   "author": "Calvin forked from anpigon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-search",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "This is a plugin to help you create game notes. Optional Steam Library Sync",
   "homepage": "https://github.com/CMorooney/obsidian-game-search-plugin",
   "main": "main.js",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -145,16 +145,10 @@ export function stringToMap(s: string): Map<string, string> {
   const lines = s.split('\n');
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].contains(':')) {
-      const components = lines[i].split(':');
+      // Split on the first colom
+      const components = lines[i].split(/:(.+)/);
       if (components[0] && components[1] && components[0].trim() && components[1].trim()) {
-        let value = '';
-        // values in the metadata can have colons in them, so there may be more than 2 elements in this array.
-        // make sure we put the string back together
-        // (without this, for example, a URL value for metadata would essentially get nuked on regen)
-        for (let i = 1; i < components.length; i++) {
-          value += components[i].trim();
-        }
-        m.set(components[0].trim(), value.trim());
+        m.set(components[0].trim(), components[1].trim());
       }
     }
   }


### PR DESCRIPTION
Hi there,

I fixed a small issue where a name like "Deep Rock Galactic: Survivor" would be formatted as "Deep Rock GalacticSurvivor" after regenerating my files. 

It was caused by splitting everything by the colon character, then trimming it an stichting it back together. That would get rid of the colon character.

My solution is to split by only the first colon, so the rest of the string remains intact!